### PR TITLE
fix(babel-preset-mcs-lite): replace babel-plugin-lodash with babel-plugin-import

### DIFF
--- a/packages/babel-preset-mcs-lite/.babelrc
+++ b/packages/babel-preset-mcs-lite/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["latest", "stage-0"]
+}

--- a/packages/babel-preset-mcs-lite/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/babel-preset-mcs-lite/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should work with mcs-lite-icon 1`] = `
+"'use strict';
+
+var _Icon = require('mcs-lite-icon/lib/Icon');
+
+var _Icon2 = _interopRequireDefault(_Icon);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+console.log(_Icon2.default);"
+`;
+
+exports[`should work with mcs-lite-icon/lib 1`] = `
+"'use strict';
+
+var _Icon = require('mcs-lite-icon/lib/Icon');
+
+var _Icon2 = _interopRequireDefault(_Icon);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+console.log(_Icon2.default);"
+`;
+
+exports[`should work with mcs-lite-ui 1`] = `
+"'use strict';
+
+var _Button = require('mcs-lite-ui/lib/Button');
+
+var _Button2 = _interopRequireDefault(_Button);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+console.log(_Button2.default);"
+`;
+
+exports[`should work with mcs-lite-ui/lib 1`] = `
+"'use strict';
+
+var _Button = require('mcs-lite-ui/lib/Button');
+
+var _Button2 = _interopRequireDefault(_Button);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+console.log(_Button2.default);"
+`;
+
+exports[`should work with ramda 1`] = `
+"'use strict';
+
+var _pipe = require('ramda/src/pipe');
+
+var _pipe2 = _interopRequireDefault(_pipe);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+console.log(_pipe2.default);"
+`;
+
+exports[`should work with ramda/src 1`] = `
+"'use strict';
+
+var _pipe = require('ramda/src/pipe');
+
+var _pipe2 = _interopRequireDefault(_pipe);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+console.log(_pipe2.default);"
+`;

--- a/packages/babel-preset-mcs-lite/__tests__/index.test.js
+++ b/packages/babel-preset-mcs-lite/__tests__/index.test.js
@@ -1,0 +1,51 @@
+import * as babel from 'babel-core';
+import mcsLitePreset from '../index';
+
+const babelOptions = {
+  presets: [mcsLitePreset],
+  babelrc: false,
+};
+
+const compile = code => babel.transform(code, babelOptions).code;
+
+it('should work with ramda', () => {
+  expect(compile(`
+import R from 'ramda';
+console.log(R.pipe);
+  `)).toMatchSnapshot();
+});
+
+it('should work with ramda/src', () => {
+  expect(compile(`
+import pipe from 'ramda/src/pipe';
+console.log(pipe);
+  `)).toMatchSnapshot();
+});
+
+it('should work with mcs-lite-icon', () => {
+  expect(compile(`
+import { Icon } from 'mcs-lite-icon';
+console.log(Icon);
+  `)).toMatchSnapshot();
+});
+
+it('should work with mcs-lite-icon/lib', () => {
+  expect(compile(`
+import Icon from 'mcs-lite-icon/lib/Icon';
+console.log(Icon);
+  `)).toMatchSnapshot();
+});
+
+it('should work with mcs-lite-ui', () => {
+  expect(compile(`
+import { Button } from 'mcs-lite-ui';
+console.log(Button);
+  `)).toMatchSnapshot();
+});
+
+it('should work with mcs-lite-ui/lib', () => {
+  expect(compile(`
+import Button from 'mcs-lite-ui/lib/Button';
+console.log(Button);
+  `)).toMatchSnapshot();
+});

--- a/packages/babel-preset-mcs-lite/index.js
+++ b/packages/babel-preset-mcs-lite/index.js
@@ -7,7 +7,7 @@ module.exports = {
   plugins: [
     require.resolve('babel-plugin-add-module-exports'),
 
-    // minify styled-components css
+    // Minify styled-components css
     [
       require.resolve('babel-plugin-styled-components'),
       {
@@ -17,15 +17,26 @@ module.exports = {
       },
     ],
 
+    // Optimize bundle size
     [
-      require.resolve('babel-plugin-lodash'),
-      {
-        id: [
-          'ramda',
-          'mcs-lite-ui',
-          'mcs-lite-icon',
-        ],
-      },
+      require.resolve('babel-plugin-import'),
+      [
+        {
+          libraryName: 'mcs-lite-icon',
+          libraryDirectory: 'lib',        // default: lib
+          camel2DashComponentName: false, // default: true
+        },
+        {
+          libraryName: 'mcs-lite-ui',
+          libraryDirectory: 'lib',        // default: lib
+          camel2DashComponentName: false, // default: true
+        },
+        {
+          libraryName: 'ramda',
+          libraryDirectory: 'src',        // default: lib
+          camel2DashComponentName: false, // default: true
+        },
+      ],
     ],
   ],
 };

--- a/packages/babel-preset-mcs-lite/package.json
+++ b/packages/babel-preset-mcs-lite/package.json
@@ -15,14 +15,19 @@
   "main": "index.js",
   "license": "ISC",
   "scripts": {
-    "test": "test -e index.js"
+    "test": "jest --coverage --runInBand",
+    "test:watch": "npm run test -- --watch"
   },
   "dependencies": {
     "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-plugin-lodash": "^3.2.11",
+    "babel-plugin-import": "^1.1.1",
     "babel-plugin-styled-components": "^1.0.0",
     "babel-preset-latest": "^6.22.0",
     "babel-preset-react": "^6.23.0",
     "babel-preset-stage-0": "^6.22.0"
+  },
+  "devDependencies": {
+    "babel-core": "^6.23.1",
+    "jest": "^19.0.2"
   }
 }


### PR DESCRIPTION
`babel-plugin-lodash` do not support some use cases of mcs-lite-ui:

```
import Button from 'mcs-lite-ui/lib/Button';
```

will failed