### PR TITLE
feat(mcs-lite-icon): support for react-svg-morph [BREAKING]

### DIFF
--- a/packages/mcs-lite-scripts/src/utils.js
+++ b/packages/mcs-lite-scripts/src/utils.js
@@ -20,18 +20,25 @@ const parseSVG = (xml) => {
 const template = (componentName, { children, viewBox }) => `
 import React, { PropTypes } from 'react';
 
-const ${componentName} = ({ name, size, children, ...otherProps }) =>
-  <svg
-    viewBox="${viewBox}"
-    preserveAspectRatio="xMidYMid meet"
-    fill="currentColor"
-    width={size}
-    height={size}
-    {...otherProps}
-  >
-    ${children}
-    {children}
-  </svg>;
+class ${componentName} extends React.Component {
+  render() {
+    const { size, children, ...otherProps } = this.props;
+
+    return (
+      <svg
+        viewBox="${viewBox}"
+        preserveAspectRatio="xMidYMid meet"
+        fill="currentColor"
+        width={size}
+        height={size}
+        {...otherProps}
+      >
+        ${children}
+        {children}
+      </svg>
+    );
+  }
+}
 
 ${componentName}.displayName = '${componentName}';
 ${componentName}.propTypes = {

--- a/packages/mcs-lite-ui/package.json
+++ b/packages/mcs-lite-ui/package.json
@@ -77,6 +77,7 @@
     "react-hammerjs": "^0.5.0",
     "react-motion-ui-pack": "^0.10.2",
     "react-overlays": "^0.6.12",
+    "react-svg-morph": "^0.1.10",
     "react-text-truncate": "^0.8.3",
     "recharts": "^0.21.2"
   },

--- a/packages/mcs-lite-ui/src/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/packages/mcs-lite-ui/src/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -4055,6 +4055,22 @@ exports[`Storyshots Icon [mcs-lite-icon] API 1`] = `
 </svg>
 `;
 
+exports[`Storyshots Icon [mcs-lite-icon] MorphReplace 1`] = `
+<svg
+  height={24}
+  preserveAspectRatio="xMidYMid meet"
+  viewBox="0 0 24 24"
+  width={24}
+>
+  <path
+    d="M19.9,13C19.9,13,19.9,11,19.9,11C19.9,11,7.899999999999999,11,7.899999999999999,11C7.899999999999999,11,13.399999999999999,5.5,13.399999999999999,5.5C13.399999999999999,5.5,12,4.1,12,4.1C12,4.1,4.1,12,4.1,12C4.1,12,12,19.9,12,19.9C12,19.9,13.4,18.5,13.4,18.5C13.4,18.5,7.9,13,7.9,13C7.9,13,19.9,13,19.9,13C19.9,13,19.9,13,19.9,13"
+    fill="rgba(-1,-1,-1,-1)"
+    style={Object {}}
+    transform="rotate(360 12 12)"
+  />
+</svg>
+`;
+
 exports[`Storyshots Icon [mcs-lite-icon] Spin Icon 1`] = `
 <div
   className="ftRJdL"

--- a/packages/mcs-lite-ui/src/others/Icon.example.js
+++ b/packages/mcs-lite-ui/src/others/Icon.example.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@kadira/storybook';
 import styled from 'styled-components';
+import MorphReplace from 'react-svg-morph/lib/MorphReplace';
 import * as Icons from 'mcs-lite-icon/lib/index';
 import Heading from '../Heading';
 import Card from '../Card';
@@ -34,6 +35,29 @@ const StyledCard = styled(Card)`
   padding: 16px;
 `;
 
+class StatefulMorphReplace extends React.Component {
+  state = { checked: false };
+  componentDidMount = () => {
+    this.interval = setInterval(() => {
+      this.setState(prevState => ({ checked: !prevState.checked }));
+    }, 1000);
+  }
+  componentWillUnmount = () => {
+    clearInterval(this.interval);
+  }
+
+  render() {
+    return (
+      <MorphReplace width={24} height={24}>
+        {this.state.checked
+          ? <Icons.IconMenu key="menu" />
+          : <Icons.IconArrowLeft key="arrow" />
+        }
+      </MorphReplace>
+    );
+  }
+}
+
 storiesOf('Icon [mcs-lite-icon]')
   .addWithInfo(
     'API',
@@ -50,6 +74,12 @@ storiesOf('Icon [mcs-lite-icon]')
         <Icons.IconLoading />
       </Spin>,
     { inline: true },
+  )
+  .addWithInfo(
+    'MorphReplace',
+    'https://github.com/gorangajic/react-svg-morph',
+    () => <StatefulMorphReplace />,
+    { inline: true, propTables: [MorphReplace]},
   )
   .addWithInfo(
     'Icon list, Custom color and size [Skip]',


### PR DESCRIPTION
## Breaking
mcs-lite-icon

Switch `functional` to `class` component 