### PR TITLE
fix(react-helmet): use plain HTML for 5.0.0

### DIFF
--- a/packages/mcs-lite-mobile-web/src/containers/Account/Account.js
+++ b/packages/mcs-lite-mobile-web/src/containers/Account/Account.js
@@ -12,7 +12,7 @@ const VERSION = packageJSON.version;
 
 const Account = ({ userName, email, signout, getMessages: t }) =>
   <Container>
-    <Helmet title={t('account')} />
+    <Helmet><title>{t('account')}</title></Helmet>
     <Body>
       <StyledLogo />
       <Heading level={4}>{userName}</Heading>

--- a/packages/mcs-lite-mobile-web/src/containers/Account/__tests__/__snapshots__/Account.test.js.snap
+++ b/packages/mcs-lite-mobile-web/src/containers/Account/__tests__/__snapshots__/Account.test.js.snap
@@ -1,8 +1,11 @@
 exports[`test should renders <Account> correctly 1`] = `
 <styled.div>
   <HelmetWrapper
-    encodeSpecialCharacters={true}
-    title="account" />
+    encodeSpecialCharacters={true}>
+    <title>
+      account
+    </title>
+  </HelmetWrapper>
   <styled.div>
     <styled.img
       alt="MCS Lite Logo"

--- a/packages/mcs-lite-mobile-web/src/containers/DeviceDataChannelDetail/DeviceDataChannelDetail.js
+++ b/packages/mcs-lite-mobile-web/src/containers/DeviceDataChannelDetail/DeviceDataChannelDetail.js
@@ -78,7 +78,7 @@ class DeviceDataChannelDetail extends React.Component {
 
     return (
       <div>
-        <Helmet title={t('dataChannelDetail')} />
+        <Helmet><title>{t('dataChannelDetail')}</title></Helmet>
         <MobileHeader.MobileHeader
           title={t('dataChannelDetail')}
           leftChildren={

--- a/packages/mcs-lite-mobile-web/src/containers/DeviceDataChannelDetail/__tests__/__snapshots__/DeviceDataChannelDetail.test.js.snap
+++ b/packages/mcs-lite-mobile-web/src/containers/DeviceDataChannelDetail/__tests__/__snapshots__/DeviceDataChannelDetail.test.js.snap
@@ -6,8 +6,11 @@ exports[`test should renders <DeviceDataChannelDetail> correctly with Notificati
 exports[`test should renders <DeviceDataChannelDetail> correctly without data 1`] = `
 <div>
   <HelmetWrapper
-    encodeSpecialCharacters={true}
-    title="dataChannelDetail" />
+    encodeSpecialCharacters={true}>
+    <title>
+      dataChannelDetail
+    </title>
+  </HelmetWrapper>
   <MobileHeader
     leftChildren={
       <MobileHeaderIcon

--- a/packages/mcs-lite-mobile-web/src/containers/DeviceDataChannelTimeRange/DeviceDataChannelTimeRange.js
+++ b/packages/mcs-lite-mobile-web/src/containers/DeviceDataChannelTimeRange/DeviceDataChannelTimeRange.js
@@ -58,7 +58,7 @@ class DeviceDataChannelTimeRange extends React.Component {
 
     return (
       <div>
-        <Helmet title={t('searchTimeRange')} />
+        <Helmet><title>{t('searchTimeRange')}</title></Helmet>
         <MobileHeader.MobileHeader
           title={t('searchTimeRange')}
           leftChildren={

--- a/packages/mcs-lite-mobile-web/src/containers/DeviceDataChannelTimeRange/__tests__/__snapshots__/DeviceDataChannelTimeRange.test.js.snap
+++ b/packages/mcs-lite-mobile-web/src/containers/DeviceDataChannelTimeRange/__tests__/__snapshots__/DeviceDataChannelTimeRange.test.js.snap
@@ -1,8 +1,11 @@
 exports[`test should renders <DeviceDataChannelTimeRange> correctly 1`] = `
 <div>
   <HelmetWrapper
-    encodeSpecialCharacters={true}
-    title="searchTimeRange" />
+    encodeSpecialCharacters={true}>
+    <title>
+      searchTimeRange
+    </title>
+  </HelmetWrapper>
   <MobileHeader
     leftChildren={
       <MobileHeaderIcon

--- a/packages/mcs-lite-mobile-web/src/containers/DeviceDetail/DeviceDetail.js
+++ b/packages/mcs-lite-mobile-web/src/containers/DeviceDetail/DeviceDetail.js
@@ -69,7 +69,7 @@ class DeviceDetail extends React.Component {
     const { getTarget, onMoreDetailClick, onHide, reFetch, eventHandler } = this;
     return (
       <div>
-        <Helmet title={device.deviceName} />
+        <Helmet><title>{device.deviceName}</title></Helmet>
         <MobileHeader.MobileHeader
           title={device.deviceName}
           leftChildren={

--- a/packages/mcs-lite-mobile-web/src/containers/DeviceDetail/__tests__/__snapshots__/DeviceDetail.test.js.snap
+++ b/packages/mcs-lite-mobile-web/src/containers/DeviceDetail/__tests__/__snapshots__/DeviceDetail.test.js.snap
@@ -1,8 +1,11 @@
 exports[`test should renders <DeviceDetail> correctly 1`] = `
 <div>
   <HelmetWrapper
-    encodeSpecialCharacters={true}
-    title="deviceName" />
+    encodeSpecialCharacters={true}>
+    <title>
+      deviceName
+    </title>
+  </HelmetWrapper>
   <MobileHeader
     leftChildren={
       <MobileHeaderIcon
@@ -46,7 +49,9 @@ exports[`test should renders <DeviceDetail> correctly 1`] = `
 exports[`test should renders <DeviceDetail> correctly when Menu show 1`] = `
 <div>
   <HelmetWrapper
-    encodeSpecialCharacters={true} />
+    encodeSpecialCharacters={true}>
+    <title />
+  </HelmetWrapper>
   <MobileHeader
     leftChildren={
       <MobileHeaderIcon

--- a/packages/mcs-lite-mobile-web/src/containers/DeviceDetailInfo/DeviceDetailInfo.js
+++ b/packages/mcs-lite-mobile-web/src/containers/DeviceDetailInfo/DeviceDetailInfo.js
@@ -26,7 +26,7 @@ class DeviceDetailInfo extends React.Component {
 
     return (
       <div>
-        <Helmet title={t('deviceIntro')} />
+        <Helmet><title>{t('deviceIntro')}</title></Helmet>
         <MobileHeader.MobileHeader
           title={t('deviceIntro')}
           leftChildren={

--- a/packages/mcs-lite-mobile-web/src/containers/DeviceDetailInfo/__tests__/__snapshots__/DeviceDetailInfo.test.js.snap
+++ b/packages/mcs-lite-mobile-web/src/containers/DeviceDetailInfo/__tests__/__snapshots__/DeviceDetailInfo.test.js.snap
@@ -1,8 +1,11 @@
 exports[`test should renders <DeviceDetailInfo> correctly 1`] = `
 <div>
   <HelmetWrapper
-    encodeSpecialCharacters={true}
-    title="deviceIntro" />
+    encodeSpecialCharacters={true}>
+    <title>
+      deviceIntro
+    </title>
+  </HelmetWrapper>
   <MobileHeader
     leftChildren={
       <MobileHeaderIcon
@@ -71,7 +74,9 @@ exports[`test should renders <DeviceDetailInfo> correctly 1`] = `
 exports[`test should renders <DeviceDetailInfo> correctly without device data 1`] = `
 <div>
   <HelmetWrapper
-    encodeSpecialCharacters={true} />
+    encodeSpecialCharacters={true}>
+    <title />
+  </HelmetWrapper>
   <MobileHeader
     leftChildren={
       <MobileHeaderIcon

--- a/packages/mcs-lite-mobile-web/src/containers/DeviceList/DeviceList.js
+++ b/packages/mcs-lite-mobile-web/src/containers/DeviceList/DeviceList.js
@@ -51,7 +51,7 @@ class DeviceList extends React.Component {
 
     return (
       <div>
-        <Helmet title={t('myTestDevices')} />
+        <Helmet><title>{t('myTestDevices')}</title></Helmet>
         <MobileHeader.MobileHeader
           title={isFilterOpen ? '' : t('myTestDevices')}
           leftChildren={

--- a/packages/mcs-lite-mobile-web/src/containers/DeviceList/__tests__/__snapshots__/DeviceList.test.js.snap
+++ b/packages/mcs-lite-mobile-web/src/containers/DeviceList/__tests__/__snapshots__/DeviceList.test.js.snap
@@ -1,8 +1,11 @@
 exports[`test should renders <DeviceList> correctly when Filter open 1`] = `
 <div>
   <HelmetWrapper
-    encodeSpecialCharacters={true}
-    title="myTestDevices" />
+    encodeSpecialCharacters={true}>
+    <title>
+      myTestDevices
+    </title>
+  </HelmetWrapper>
   <MobileHeader
     leftChildren={
       <MobileHeaderIcon
@@ -93,8 +96,11 @@ exports[`test should renders <DeviceList> correctly when Filter open 1`] = `
 exports[`test should renders <DeviceList> correctly with one device 1`] = `
 <div>
   <HelmetWrapper
-    encodeSpecialCharacters={true}
-    title="myTestDevices" />
+    encodeSpecialCharacters={true}>
+    <title>
+      myTestDevices
+    </title>
+  </HelmetWrapper>
   <MobileHeader
     leftChildren={
       <MobileHeaderIcon
@@ -166,8 +172,11 @@ exports[`test should renders <DeviceList> correctly with one device 1`] = `
 exports[`test should renders <DeviceList> correctly without devices 1`] = `
 <div>
   <HelmetWrapper
-    encodeSpecialCharacters={true}
-    title="myTestDevices" />
+    encodeSpecialCharacters={true}>
+    <title>
+      myTestDevices
+    </title>
+  </HelmetWrapper>
   <MobileHeader
     leftChildren={
       <MobileHeaderIcon

--- a/packages/mcs-lite-mobile-web/src/containers/DeviceTrigger/DeviceTrigger.js
+++ b/packages/mcs-lite-mobile-web/src/containers/DeviceTrigger/DeviceTrigger.js
@@ -27,7 +27,7 @@ class DeviceTrigger extends React.Component {
 
     return (
       <div>
-        <Helmet title={t('triggerAndAction')} />
+        <Helmet><title>{t('triggerAndAction')}</title></Helmet>
         <MobileHeader.MobileHeader
           title={t('triggerAndAction')}
           leftChildren={

--- a/packages/mcs-lite-mobile-web/src/containers/DeviceTrigger/__tests__/__snapshots__/DeviceTrigger.test.js.snap
+++ b/packages/mcs-lite-mobile-web/src/containers/DeviceTrigger/__tests__/__snapshots__/DeviceTrigger.test.js.snap
@@ -1,8 +1,11 @@
 exports[`test should renders <DeviceTrigger> correctly 1`] = `
 <div>
   <HelmetWrapper
-    encodeSpecialCharacters={true}
-    title="triggerAndAction" />
+    encodeSpecialCharacters={true}>
+    <title>
+      triggerAndAction
+    </title>
+  </HelmetWrapper>
   <MobileHeader
     leftChildren={
       <MobileHeaderIcon

--- a/packages/mcs-lite-mobile-web/src/containers/DeviceTriggerEdit/DeviceTriggerEdit.js
+++ b/packages/mcs-lite-mobile-web/src/containers/DeviceTriggerEdit/DeviceTriggerEdit.js
@@ -29,7 +29,7 @@ class DeviceTriggerEdit extends React.Component {
 
     return (
       <div>
-        <Helmet title={t('editTriggerAndAction')} />
+        <Helmet><title>{t('editTriggerAndAction')}</title></Helmet>
         <MobileHeader.MobileHeader
           title={t('editTriggerAndAction')}
           leftChildren={

--- a/packages/mcs-lite-mobile-web/src/containers/DeviceTriggerEdit/__tests__/__snapshots__/DeviceTriggerEdit.test.js.snap
+++ b/packages/mcs-lite-mobile-web/src/containers/DeviceTriggerEdit/__tests__/__snapshots__/DeviceTriggerEdit.test.js.snap
@@ -1,8 +1,11 @@
 exports[`test should renders <DeviceTriggerEdit> correctly 1`] = `
 <div>
   <HelmetWrapper
-    encodeSpecialCharacters={true}
-    title="editTriggerAndAction" />
+    encodeSpecialCharacters={true}>
+    <title>
+      editTriggerAndAction
+    </title>
+  </HelmetWrapper>
   <MobileHeader
     leftChildren={
       <MobileHeaderIcon

--- a/packages/mcs-lite-mobile-web/src/containers/Password/Password.js
+++ b/packages/mcs-lite-mobile-web/src/containers/Password/Password.js
@@ -34,7 +34,7 @@ class Password extends React.Component {
 
     return (
       <div>
-        <Helmet title={t('changePassword')} />
+        <Helmet><title>{t('changePassword')}</title></Helmet>
         <MobileHeader.MobileHeader
           title={t('changePassword')}
           leftChildren={

--- a/packages/mcs-lite-mobile-web/src/containers/Password/__tests__/__snapshots__/Password.test.js.snap
+++ b/packages/mcs-lite-mobile-web/src/containers/Password/__tests__/__snapshots__/Password.test.js.snap
@@ -1,8 +1,11 @@
 exports[`test should render with error mesage 1`] = `
 <div>
   <HelmetWrapper
-    encodeSpecialCharacters={true}
-    title="changePassword" />
+    encodeSpecialCharacters={true}>
+    <title>
+      changePassword
+    </title>
+  </HelmetWrapper>
   <MobileHeader
     leftChildren={
       <MobileHeaderIcon
@@ -87,8 +90,11 @@ exports[`test should render with error mesage 1`] = `
 exports[`test should renders <Password> correctly 1`] = `
 <div>
   <HelmetWrapper
-    encodeSpecialCharacters={true}
-    title="changePassword" />
+    encodeSpecialCharacters={true}>
+    <title>
+      changePassword
+    </title>
+  </HelmetWrapper>
   <MobileHeader
     leftChildren={
       <MobileHeaderIcon

--- a/packages/mcs-lite-mobile-web/src/containers/Signin/Signin.js
+++ b/packages/mcs-lite-mobile-web/src/containers/Signin/Signin.js
@@ -25,7 +25,7 @@ class Signin extends React.Component {
 
     return (
       <Layout>
-        <Helmet title={t('signin')} />
+        <Helmet><title>{t('signin')}</title></Helmet>
 
         <Logo />
         {errorMessage && <ErrorMessage color="error">{errorMessage}</ErrorMessage>}

--- a/packages/mcs-lite-mobile-web/src/containers/Signin/__tests__/__snapshots__/Signin.test.js.snap
+++ b/packages/mcs-lite-mobile-web/src/containers/Signin/__tests__/__snapshots__/Signin.test.js.snap
@@ -1,8 +1,11 @@
 exports[`test should renders <Signin> correctly 1`] = `
 <styled.div>
   <HelmetWrapper
-    encodeSpecialCharacters={true}
-    title="signin" />
+    encodeSpecialCharacters={true}>
+    <title>
+      signin
+    </title>
+  </HelmetWrapper>
   <Logo
     alt="MCS Lite Logo"
     src="logo_mcs_lite_black.svg" />
@@ -44,8 +47,11 @@ exports[`test should renders <Signin> correctly 1`] = `
 exports[`test should renders <Signin> correctly with errorMessage 1`] = `
 <styled.div>
   <HelmetWrapper
-    encodeSpecialCharacters={true}
-    title="signin" />
+    encodeSpecialCharacters={true}>
+    <title>
+      signin
+    </title>
+  </HelmetWrapper>
   <Logo
     alt="MCS Lite Logo"
     src="logo_mcs_lite_black.svg" />


### PR DESCRIPTION
https://github.com/nfl/react-helmet/blob/master/CHANGELOG.md#features
> New Simplified API (fully backward-compatible) - Helmet now takes plain HTML tags for the majority of the API with just a few remaining props for Helmet - retaining titleTemplate, defaultTitle, onChangeClientState, and one new - encodeSpecialCharacters - refer to README for details. Directly passing Helmet props will be deprecated in the future. (#246)