### PR TITLE
fix(gitbook): add npmrc for --save behavior of npm@5

### DIFF
--- a/packages/mcs-lite-introduction/.npmrc
+++ b/packages/mcs-lite-introduction/.npmrc
@@ -1,0 +1,1 @@
+save=false # disable npm@5 --save by default.


### PR DESCRIPTION
disable npm@5 `--save` by default.

#333 