### PR TITLE
feat(Admin/Codemirror): code split with react-loadable

### DIFF
--- a/packages/mcs-lite-admin-web/src/containers/App/__tests__/styled-components.test.js
+++ b/packages/mcs-lite-admin-web/src/containers/App/__tests__/styled-components.test.js
@@ -5,8 +5,6 @@ import { ThemeProvider } from 'styled-components';
 import { theme } from 'mcs-lite-theme';
 import { HeightContainer, Fixed, ToastContainer } from '../styled-components';
 
-jest.mock('mcs-lite-ui');
-
 it('should render components correctly', () => {
   const wrapper = mount(
     <ThemeProvider theme={theme}>

--- a/packages/mcs-lite-admin-web/src/containers/DashboardLayout/__tests__/__snapshots__/styled-components.test.js.snap
+++ b/packages/mcs-lite-admin-web/src/containers/DashboardLayout/__tests__/__snapshots__/styled-components.test.js.snap
@@ -5,56 +5,56 @@ Array [
   <div>
     <styled.div>
         <div
-            className="sc-htpNat lYQhy"
+            className="sc-bwzfXH gPmFGo"
         />
     </styled.div>
     <styled.header>
         <header
-            className="sc-bxivhb dXzFIJ"
+            className="sc-htpNat kbxgiD"
         />
     </styled.header>
     <styled.div>
         <div
-            className="sc-ifAKCX gXKEbp"
+            className="sc-bxivhb uzCBi"
         />
     </styled.div>
     <styled.div>
         <div
-            className="sc-EHOje dsvIkb"
+            className="sc-ifAKCX jpDVsq"
         />
     </styled.div>
     <Styled(Logo)>
         <Logo
             alt="MCS Lite Logo"
-            className="sc-bZQynM bMPIqW"
+            className="sc-EHOje dQwnkZ"
             src="logo_mcs_lite_black.svg"
         >
             <img
                 alt="MCS Lite Logo"
-                className="sc-bZQynM bMPIqW sc-bwzfXH eoGWgM"
+                className="sc-EHOje dQwnkZ sc-bdVaJa RUnCB"
                 src="logo_mcs_lite_black.svg"
             />
         </Logo>
     </Styled(Logo)>
     <styled.div>
         <div
-            className="sc-gzVnrw cejBzL"
+            className="sc-bZQynM ijZMir"
         />
     </styled.div>
     <styled.nav>
         <nav
-            className="sc-htoDjs flOUgP"
+            className="sc-gzVnrw gDjQsG"
         />
     </styled.nav>
     <Styled(Link)>
         <Link
             activeClassName="DashboardLayout-SC-NavItem-attrs-activeClassName"
-            className="sc-dnqmqq eiXBHA"
+            className="sc-htoDjs ckroVS"
             onlyActiveOnIndex={false}
             style={Object {}}
         >
             <a
-                className="sc-dnqmqq eiXBHA"
+                className="sc-htoDjs ckroVS"
                 onClick={[Function]}
                 style={Object {}}
             />
@@ -62,16 +62,16 @@ Array [
     </Styled(Link)>
     <Styled(Styled(Link))>
         <Styled(Link)
-            className="sc-iwsKbI iVYsde"
+            className="sc-dnqmqq fbtjeC"
         >
             <Link
                 activeClassName="DashboardLayout-SC-NavItem-attrs-activeClassName"
-                className="sc-iwsKbI iVYsde sc-dnqmqq eiXBHA"
+                className="sc-dnqmqq fbtjeC sc-htoDjs ckroVS"
                 onlyActiveOnIndex={false}
                 style={Object {}}
             >
                 <a
-                    className="sc-iwsKbI iVYsde sc-dnqmqq eiXBHA"
+                    className="sc-dnqmqq fbtjeC sc-htoDjs ckroVS"
                     onClick={[Function]}
                     style={Object {}}
                 />
@@ -80,21 +80,21 @@ Array [
     </Styled(Styled(Link))>
     <styled.main>
         <main
-            className="sc-gZMcBi iJCugY"
+            className="sc-iwsKbI jSuezg"
         />
     </styled.main>
 </div>,
   <div
-    className="sc-htpNat lYQhy"
+    className="sc-bwzfXH gPmFGo"
 />,
   <div
-    className="sc-ifAKCX gXKEbp"
+    className="sc-bxivhb uzCBi"
 />,
   <div
-    className="sc-EHOje dsvIkb"
+    className="sc-ifAKCX jpDVsq"
 />,
   <div
-    className="sc-gzVnrw cejBzL"
+    className="sc-bZQynM ijZMir"
 />,
 ]
 `;

--- a/packages/mcs-lite-admin-web/src/containers/DashboardLayout/__tests__/styled-components.test.js
+++ b/packages/mcs-lite-admin-web/src/containers/DashboardLayout/__tests__/styled-components.test.js
@@ -16,7 +16,7 @@ import {
   Main,
 } from '../styled-components';
 
-jest.mock('mcs-lite-ui');
+jest.mock('mcs-lite-ui/lib/P');
 
 it('should render components correctly', () => {
   const wrapper = mount(

--- a/packages/mcs-lite-admin-web/src/containers/Ip/__tests__/__snapshots__/styled-components.test.js.snap
+++ b/packages/mcs-lite-admin-web/src/containers/Ip/__tests__/__snapshots__/styled-components.test.js.snap
@@ -7,39 +7,23 @@ Array [
         <Button
             active={false}
             block={false}
-            className="sc-bwzfXH jQNUeE"
+            className="sc-bdVaJa byrdwB"
             component="button"
             disabled={false}
             kind="primary"
             round={false}
             size="normal"
             square={false}
-        >
-            <BaseComponent
-                active={false}
-                block={false}
-                className="sc-bwzfXH jQNUeE sc-bdVaJa kDgzfK"
-                component="button"
-                disabled={false}
-                kind="primary"
-                round={false}
-                size="normal"
-                square={false}
-            >
-                <button
-                    className="sc-bwzfXH jQNUeE sc-bdVaJa kDgzfK"
-                />
-            </BaseComponent>
-        </Button>
+        />
     </Styled(Button)>
     <styled.div>
         <div
-            className="sc-htpNat iqOCg"
+            className="sc-bwzfXH eQuOHF"
         />
     </styled.div>
 </div>,
   <div
-    className="sc-htpNat iqOCg"
+    className="sc-bwzfXH eQuOHF"
 />,
 ]
 `;

--- a/packages/mcs-lite-admin-web/src/containers/Ip/__tests__/styled-components.test.js
+++ b/packages/mcs-lite-admin-web/src/containers/Ip/__tests__/styled-components.test.js
@@ -5,7 +5,7 @@ import { ThemeProvider } from 'styled-components';
 import { theme } from 'mcs-lite-theme';
 import { StyledButton, NaWrapper } from '../styled-components';
 
-jest.mock('mcs-lite-ui');
+jest.mock('mcs-lite-ui/lib/Button');
 
 it('should render components correctly', () => {
   const wrapper = mount(

--- a/packages/mcs-lite-admin-web/src/containers/Signin/Signin.js
+++ b/packages/mcs-lite-admin-web/src/containers/Signin/Signin.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Button, Input } from 'mcs-lite-ui';
+import Button from 'mcs-lite-ui/lib/Button';
+import Input from 'mcs-lite-ui/lib/Input';
 import Helmet from 'react-helmet';
 import {
   StyledLogo,

--- a/packages/mcs-lite-admin-web/src/containers/Signin/__tests__/styled-components.test.js
+++ b/packages/mcs-lite-admin-web/src/containers/Signin/__tests__/styled-components.test.js
@@ -5,7 +5,8 @@ import { ThemeProvider } from 'styled-components';
 import { theme } from 'mcs-lite-theme';
 import { StyledLogo, ErrorMessage, Layout, Form } from '../styled-components';
 
-jest.mock('mcs-lite-ui');
+jest.mock('mcs-lite-ui/lib/P');
+jest.mock('mcs-lite-ui/lib/Hr');
 
 it('should render components correctly', () => {
   const wrapper = mount(

--- a/packages/mcs-lite-admin-web/src/containers/Signin/styled-components.js
+++ b/packages/mcs-lite-admin-web/src/containers/Signin/styled-components.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
-import { Hr, P } from 'mcs-lite-ui';
+import Hr from 'mcs-lite-ui/lib/Hr';
+import P from 'mcs-lite-ui/lib/P';
 import Logo from '../../components/Logo';
 
 export const StyledLogo = styled(Logo)`

--- a/packages/mcs-lite-admin-web/src/containers/System/System.js
+++ b/packages/mcs-lite-admin-web/src/containers/System/System.js
@@ -2,8 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import R from 'ramda';
 import Helmet from 'react-helmet';
-import 'codemirror/mode/javascript/javascript';
-import 'codemirror/lib/codemirror.css';
 import TabItem from 'mcs-lite-ui/lib/TabItem';
 import isJSONValidator from 'validator/lib/isJSON';
 import DashboardTitle from '../../components/DashboardTitle';
@@ -11,7 +9,7 @@ import DashboardDesc from '../../components/DashboardDesc';
 import {
   StyledButton,
   TabWrapper,
-  StyledCodeMirror,
+  StyledLoadableCodeMirror,
   Message,
 } from './styled-components';
 
@@ -76,7 +74,7 @@ class System extends React.Component {
           )}
         </TabWrapper>
 
-        <StyledCodeMirror
+        <StyledLoadableCodeMirror
           value={code}
           onChange={onCodeMirrorChange}
           options={OPTIONS}

--- a/packages/mcs-lite-admin-web/src/containers/System/__tests__/__snapshots__/System.test.js.snap
+++ b/packages/mcs-lite-admin-web/src/containers/System/__tests__/__snapshots__/System.test.js.snap
@@ -53,7 +53,7 @@ exports[`should renders <System> correctly 1`] = `
       .json
     </TabItem>
   </styled.div>
-  <Styled(Component)
+  <Styled(Loadable)
     error={false}
     onChange={[Function]}
     options={

--- a/packages/mcs-lite-admin-web/src/containers/System/__tests__/__snapshots__/styled-components.test.js.snap
+++ b/packages/mcs-lite-admin-web/src/containers/System/__tests__/__snapshots__/styled-components.test.js.snap
@@ -14,35 +14,33 @@ Array [
             round={false}
             size="normal"
             square={false}
-        >
-            <BaseComponent
-                active={false}
-                block={false}
-                className="sc-htpNat iJpthS sc-bdVaJa kDgzfK"
-                component="button"
-                disabled={false}
-                kind="primary"
-                round={false}
-                size="normal"
-                square={false}
-            >
-                <button
-                    className="sc-htpNat iJpthS sc-bdVaJa kDgzfK"
-                />
-            </BaseComponent>
-        </Button>
+        />
     </Styled(Button)>
     <styled.div>
         <div
             className="sc-bxivhb enlRff"
         />
     </styled.div>
-    <Styled(mockConstructor)>
-        <mockConstructor
+    <Styled(Loadable)>
+        <Loadable
             className="sc-EHOje kYsIWP"
-            preserveScrollPosition={false}
-        />
-    </Styled(mockConstructor)>
+        >
+            <LoadingComponent
+                error={null}
+                isLoading={true}
+                pastDelay={false}
+            >
+                <Styled(P)
+                    color="primary"
+                >
+                    <P
+                        className="sc-bwzfXH blGNPr"
+                        color="primary"
+                    />
+                </Styled(P)>
+            </LoadingComponent>
+        </Loadable>
+    </Styled(Loadable)>
 </div>,
   <div
     className="sc-bxivhb enlRff"

--- a/packages/mcs-lite-admin-web/src/containers/System/__tests__/styled-components.test.js
+++ b/packages/mcs-lite-admin-web/src/containers/System/__tests__/styled-components.test.js
@@ -6,10 +6,11 @@ import { theme } from 'mcs-lite-theme';
 import {
   StyledButton,
   TabWrapper,
-  StyledCodeMirror,
+  StyledLoadableCodeMirror,
 } from '../styled-components';
 
-jest.mock('mcs-lite-ui');
+jest.mock('mcs-lite-ui/lib/Button');
+jest.mock('mcs-lite-ui/lib/P');
 jest.mock('react-codemirror');
 
 it('should render components correctly', () => {
@@ -18,7 +19,7 @@ it('should render components correctly', () => {
       <div>
         <StyledButton />
         <TabWrapper />
-        <StyledCodeMirror />
+        <StyledLoadableCodeMirror />
       </div>
     </ThemeProvider>,
   );

--- a/packages/mcs-lite-admin-web/src/containers/System/styled-components.js
+++ b/packages/mcs-lite-admin-web/src/containers/System/styled-components.js
@@ -1,7 +1,32 @@
+import React from 'react';
 import styled from 'styled-components';
 import Button from 'mcs-lite-ui/lib/Button';
 import P from 'mcs-lite-ui/lib/P';
-import CodeMirror from 'react-codemirror';
+import IconLoading from 'mcs-lite-icon/lib/IconLoading';
+import Spin from 'mcs-lite-ui/lib/Spin';
+import Loadable from 'react-loadable';
+
+const Center = styled(P)`
+  text-align: center;
+  padding: 20px;
+`;
+
+const LoadableCodeMirror = Loadable({
+  loader: () =>
+    Promise.all([
+      import(
+        /* webpackChunkName: "/LoadableCodeMirror" */ 'codemirror/lib/codemirror.css',
+      ),
+      import(
+        /* webpackChunkName: "/LoadableCodeMirror" */ 'codemirror/mode/javascript/javascript',
+      ),
+    ]).then(() =>
+      import(/* webpackChunkName: "/LoadableCodeMirror" */ 'react-codemirror'),
+    ),
+  LoadingComponent: () =>
+    <Center color="primary"><Spin><IconLoading size={20} /></Spin></Center>,
+  webpackRequireWeakId: () => require.resolveWeak('react-codemirror'),
+});
 
 export const StyledButton = styled(Button)`
   margin-top: 10px;
@@ -17,7 +42,7 @@ export const Message = styled(P)`
   margin-top: 5px;
 `;
 
-export const StyledCodeMirror = styled(CodeMirror)`
+export const StyledLoadableCodeMirror = styled(LoadableCodeMirror)`
   > .CodeMirror {
     border: 1px solid ${props =>
       props.error ? props.theme.color.error : props.theme.color.grayDark};


### PR DESCRIPTION
## Optimize `Codemirror` bundle size

### Before

main.js (800 kb)

### After

main.js (600 kb)
chunk.js (200 kb) - lazy load
 
## Usage

```diff
+const LoadableCodeMirror = Loadable({
+   loader: () =>
+     Promise.all([
+       import(
+         /* webpackChunkName: "/LoadableCodeMirror" */ 'codemirror/lib/codemirror.css',
+       ),
+       import(
+         /* webpackChunkName: "/LoadableCodeMirror" */ 'codemirror/mode/javascript/javascript',
+       ),
+     ]).then(() =>
+       import(/* webpackChunkName: "/LoadableCodeMirror" */ 'react-codemirror'),
+     ),
+   LoadingComponent: () =>
+     <Center color="primary"><Spin><IconLoading size={20} /></Spin></Center>,
+   webpackRequireWeakId: () => require.resolveWeak('react-codemirror'),
+ });
```