### PR TITLE
fix(Landing/Footer): mock year 新年快樂 🎉

### DIFF
--- a/packages/mcs-lite-landing-web/src/components/Footer/__tests__/Footer.test.js
+++ b/packages/mcs-lite-landing-web/src/components/Footer/__tests__/Footer.test.js
@@ -3,6 +3,8 @@ import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import Footer from '../Footer';
 
+jest.mock('mcs-lite-ui/lib/utils/getCurrentYear', () => () => 'mockYear');
+
 it('should renders <Footer> correctly', () => {
   const wrapper = shallow(<Footer getMessages={t => t} />);
 

--- a/packages/mcs-lite-landing-web/src/components/Footer/__tests__/__snapshots__/Footer.test.js.snap
+++ b/packages/mcs-lite-landing-web/src/components/Footer/__tests__/__snapshots__/Footer.test.js.snap
@@ -56,7 +56,7 @@ exports[`should renders <Footer> correctly 1`] = `
             color="white"
           >
             © 
-            2017
+            mockYear
              
             desc
           </P>

--- a/packages/mcs-lite-landing-web/src/components/Footer/__tests__/index.test.js
+++ b/packages/mcs-lite-landing-web/src/components/Footer/__tests__/index.test.js
@@ -4,6 +4,8 @@ import toJson from 'enzyme-to-json';
 import IntlProvider from '../../../containers/IntlProvider';
 import Container from '../';
 
+jest.mock('mcs-lite-ui/lib/utils/getCurrentYear', () => () => 'mockYear');
+
 it('should render Container correctly with HOC', () => {
   const wrapper = shallow(
     <IntlProvider>


### PR DESCRIPTION
Issue:

<img width="495" alt="2018-01-02 10 56 49" src="https://user-images.githubusercontent.com/1527371/34473357-9c53d78a-efac-11e7-8e49-717e519c887f.png">


## [](#what-i-did)What I did

## [](#how-to-test)How to test
