### PR TITLE
feat(avatar): add Avatar component

### DIFF
--- a/packages/mcs-lite-ui/setupTests.js
+++ b/packages/mcs-lite-ui/setupTests.js
@@ -44,3 +44,4 @@ jest.mock('./src/Popover/Arrow', () => 'Arrow-svgr.macro');
 jest.mock('./src/Tooltip/Arrow', () => 'Arrow-svgr.macro');
 jest.mock('./src/Checkbox/IconCheck', () => 'IconCheck.macro');
 jest.mock('./src/IconWarning/IconWarning', () => 'IconWarning.macro');
+jest.mock('./src/Avatar/Avatar', () => 'Avatar.macro');

--- a/packages/mcs-lite-ui/src/Avatar/Avatar.example.js
+++ b/packages/mcs-lite-ui/src/Avatar/Avatar.example.js
@@ -1,0 +1,21 @@
+// @flow
+import * as React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+import Avatar from './Avatar';
+
+storiesOf('Avatar', module)
+  .add(
+    'API',
+    withInfo({
+      text: '',
+      inline: true,
+    })(() => <Avatar size={30} src="//placehold.it/50x50" />),
+  )
+  .add(
+    'default',
+    withInfo({
+      text: '',
+      inline: true,
+    })(() => <Avatar />),
+  );

--- a/packages/mcs-lite-ui/src/Avatar/Avatar.example.js
+++ b/packages/mcs-lite-ui/src/Avatar/Avatar.example.js
@@ -6,16 +6,30 @@ import Avatar from './Avatar';
 
 storiesOf('Avatar', module)
   .add(
-    'API',
-    withInfo({
-      text: '',
-      inline: true,
-    })(() => <Avatar size={30} src="//placehold.it/50x50" />),
-  )
-  .add(
-    'default',
+    'Default',
     withInfo({
       text: '',
       inline: true,
     })(() => <Avatar />),
+  )
+  .add(
+    'Default - Large',
+    withInfo({
+      text: '',
+      inline: true,
+    })(() => <Avatar size={150} />),
+  )
+  .add(
+    'With Url',
+    withInfo({
+      text: '',
+      inline: true,
+    })(() => <Avatar src="//placehold.it/30x30" />),
+  )
+  .add(
+    'With Url - Large',
+    withInfo({
+      text: '',
+      inline: true,
+    })(() => <Avatar size={150} src="//placehold.it/150x150" />),
   );

--- a/packages/mcs-lite-ui/src/Avatar/Avatar.js
+++ b/packages/mcs-lite-ui/src/Avatar/Avatar.js
@@ -22,7 +22,7 @@ function PureAvatar({ src, size }: Props) {
   );
 }
 
-const Avatar: React.ComponentType<Props> = pure(PureAvatar);
+const Avatar = pure(PureAvatar);
 Avatar.displayName = 'Avatar';
 Avatar.defaultProps = {
   size: 30,

--- a/packages/mcs-lite-ui/src/Avatar/Avatar.js
+++ b/packages/mcs-lite-ui/src/Avatar/Avatar.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { pure } from 'recompose';
 import IconAvatar from './IconAvatar';
 import Wrapper from './styled-components';
 
@@ -10,7 +9,7 @@ type Props = {
   size?: number,
 };
 
-function PureAvatar({ src, size }: Props) {
+function Avatar({ src, size }: Props) {
   return (
     <Wrapper>
       {src ? (
@@ -22,7 +21,6 @@ function PureAvatar({ src, size }: Props) {
   );
 }
 
-const Avatar = pure(PureAvatar);
 Avatar.displayName = 'Avatar';
 Avatar.defaultProps = {
   size: 30,

--- a/packages/mcs-lite-ui/src/Avatar/Avatar.js
+++ b/packages/mcs-lite-ui/src/Avatar/Avatar.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { compose, pure } from 'recompose';
+import { pure } from 'recompose';
 import IconAvatar from './IconAvatar';
 import Wrapper from './styled-components';
 
@@ -22,8 +22,7 @@ function PureAvatar({ src, size }: Props) {
   );
 }
 
-const enhance = compose(pure);
-const Avatar: React.ComponentType<Props> = enhance(PureAvatar);
+const Avatar: React.ComponentType<Props> = pure(PureAvatar);
 Avatar.displayName = 'Avatar';
 Avatar.defaultProps = {
   size: '30',

--- a/packages/mcs-lite-ui/src/Avatar/Avatar.js
+++ b/packages/mcs-lite-ui/src/Avatar/Avatar.js
@@ -21,16 +21,16 @@ function PureAvatar({ src, size }: Props) {
     </Wrapper>
   );
 }
-PureAvatar.defaultProps = {
-  size: '30',
-};
-PureAvatar.propTypes = {
-  src: PropTypes.string,
-  size: PropTypes.string,
-};
 
 const enhance = compose(pure);
 const Avatar: React.ComponentType<Props> = enhance(PureAvatar);
 Avatar.displayName = 'Avatar';
+Avatar.defaultProps = {
+  size: '30',
+};
+Avatar.propTypes = {
+  src: PropTypes.string,
+  size: PropTypes.string,
+};
 
 export default Avatar;

--- a/packages/mcs-lite-ui/src/Avatar/Avatar.js
+++ b/packages/mcs-lite-ui/src/Avatar/Avatar.js
@@ -27,7 +27,7 @@ Avatar.defaultProps = {
 };
 Avatar.propTypes = {
   src: PropTypes.string,
-  size: PropTypes.string,
+  size: PropTypes.number,
 };
 
 export default Avatar;

--- a/packages/mcs-lite-ui/src/Avatar/Avatar.js
+++ b/packages/mcs-lite-ui/src/Avatar/Avatar.js
@@ -1,0 +1,26 @@
+// @flow
+import * as React from 'react';
+import { compose, pure } from 'recompose';
+import IconAvatar from './IconAvatar';
+import Wrapper from './styled-components';
+
+type Props = {
+  src?: string,
+  size?: number,
+};
+
+const PureAvatar = ({ src, size = 30 }: Props) => (
+  <Wrapper>
+    {src ? (
+      <img alt="" src={src} width={size} height={size} />
+    ) : (
+      <IconAvatar width={size} height={size} />
+    )}
+  </Wrapper>
+);
+
+const enhance = compose(pure);
+const Avatar: React.ComponentType<Props> = enhance(PureAvatar);
+Avatar.displayName = 'Avatar';
+
+export default Avatar;

--- a/packages/mcs-lite-ui/src/Avatar/Avatar.js
+++ b/packages/mcs-lite-ui/src/Avatar/Avatar.js
@@ -25,7 +25,7 @@ function PureAvatar({ src, size }: Props) {
 const Avatar: React.ComponentType<Props> = pure(PureAvatar);
 Avatar.displayName = 'Avatar';
 Avatar.defaultProps = {
-  size: '30',
+  size: 30,
 };
 Avatar.propTypes = {
   src: PropTypes.string,

--- a/packages/mcs-lite-ui/src/Avatar/Avatar.js
+++ b/packages/mcs-lite-ui/src/Avatar/Avatar.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import { compose, pure } from 'recompose';
 import IconAvatar from './IconAvatar';
 import Wrapper from './styled-components';
@@ -9,15 +10,24 @@ type Props = {
   size?: number,
 };
 
-const PureAvatar = ({ src, size = 30 }: Props) => (
-  <Wrapper>
-    {src ? (
-      <img alt="" src={src} width={size} height={size} />
-    ) : (
-      <IconAvatar width={size} height={size} />
-    )}
-  </Wrapper>
-);
+function PureAvatar({ src, size }: Props) {
+  return (
+    <Wrapper>
+      {src ? (
+        <img alt="" src={src} width={size} height={size} />
+      ) : (
+        <IconAvatar width={size} height={size} />
+      )}
+    </Wrapper>
+  );
+}
+PureAvatar.defaultProps = {
+  size: '30',
+};
+PureAvatar.propTypes = {
+  src: PropTypes.string,
+  size: PropTypes.string,
+};
 
 const enhance = compose(pure);
 const Avatar: React.ComponentType<Props> = enhance(PureAvatar);

--- a/packages/mcs-lite-ui/src/Avatar/IconAvatar.js
+++ b/packages/mcs-lite-ui/src/Avatar/IconAvatar.js
@@ -1,0 +1,17 @@
+// @flow
+import * as React from 'react'; // eslint-disable-line
+import toReactComponent from 'svgr.macro';
+
+type Props = {
+  width?: number,
+  height?: number,
+};
+
+const IconAvatar: React.ComponentType<Props> = toReactComponent(
+  './svg/avatar.svg',
+  {
+    icon: true,
+  },
+);
+
+export default IconAvatar;

--- a/packages/mcs-lite-ui/src/Avatar/__snapshots__/Avatar.example.storyshot
+++ b/packages/mcs-lite-ui/src/Avatar/__snapshots__/Avatar.example.storyshot
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Avatar API 1`] = `
+<Avatar.macro
+  size={30}
+  src="//placehold.it/50x50"
+/>
+`;
+
+exports[`Storyshots Avatar default 1`] = `<Avatar.macro />`;

--- a/packages/mcs-lite-ui/src/Avatar/__snapshots__/Avatar.example.storyshot
+++ b/packages/mcs-lite-ui/src/Avatar/__snapshots__/Avatar.example.storyshot
@@ -1,10 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Avatar API 1`] = `
+exports[`Storyshots Avatar Default - Large 1`] = `
 <Avatar.macro
-  size={30}
-  src="//placehold.it/50x50"
+  size={150}
 />
 `;
 
-exports[`Storyshots Avatar default 1`] = `<Avatar.macro />`;
+exports[`Storyshots Avatar Default 1`] = `<Avatar.macro />`;
+
+exports[`Storyshots Avatar With Url - Large 1`] = `
+<Avatar.macro
+  size={150}
+  src="//placehold.it/150x150"
+/>
+`;
+
+exports[`Storyshots Avatar With Url 1`] = `
+<Avatar.macro
+  src="//placehold.it/30x30"
+/>
+`;

--- a/packages/mcs-lite-ui/src/Avatar/index.js
+++ b/packages/mcs-lite-ui/src/Avatar/index.js
@@ -1,0 +1,4 @@
+// @flow
+import Avatar from './Avatar';
+
+export default Avatar;

--- a/packages/mcs-lite-ui/src/Avatar/styled-components.js
+++ b/packages/mcs-lite-ui/src/Avatar/styled-components.js
@@ -1,0 +1,18 @@
+// @flow
+import * as React from 'react';
+import styled from 'styled-components';
+
+const Wrapper: React.ComponentType<*> = styled.div`
+  img,
+  svg {
+    display: inline-block;
+    border-radius: 50%;
+    border: 1px solid #d1d3d4;
+    padding: 1px;
+    background: #ffffff;
+    box-sizing: border-box;
+    object-fit: cover;
+  }
+`;
+
+export default Wrapper;

--- a/packages/mcs-lite-ui/src/Avatar/styled-components.js
+++ b/packages/mcs-lite-ui/src/Avatar/styled-components.js
@@ -7,9 +7,9 @@ const Wrapper: React.ComponentType<*> = styled.div`
   svg {
     display: inline-block;
     border-radius: 50%;
-    border: 1px solid #d1d3d4;
+    border: 1px solid ${props => props.theme.color.grayDark};
     padding: 1px;
-    background: #ffffff;
+    background: ${props => props.theme.color.white};
     box-sizing: border-box;
     object-fit: cover;
   }

--- a/packages/mcs-lite-ui/src/Avatar/svg/avatar.svg
+++ b/packages/mcs-lite-ui/src/Avatar/svg/avatar.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="avatar" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 300 300" enable-background="new 0 0 300 300" xml:space="preserve">
+<rect id="bounds" fill="none" width="300" height="300"/>
+<path fill="#D0D2D3" d="M185.9,209.7v-9.5c8-8.7,14.2-20.1,18.1-33.2c5.8-4.8,9.3-12.1,9.3-19.8c0-5.3-1.6-10.3-4.6-14.7v-26.4
+	c0-34.5-21.3-54.2-58.5-54.2c-36.6,0-58.5,20.3-58.5,54.2v26.4c-3,4.3-4.6,9.4-4.6,14.6c0,7.7,3.4,15,9.2,19.8
+	c3.9,13.1,10.1,24.6,18.1,33.3v9.5c-1.9,3.9-16.5,15.4-76.7,39.4c27.5,31.2,67.6,51,112.4,51c44.7,0,84.7-19.7,112.2-50.7
+	C202.2,225.4,187.8,213.6,185.9,209.7z"/>
+</svg>


### PR DESCRIPTION
## [](#what-i-did)What I did

- add `<Avatar>` component for displaying user avatar
- add svg image for default condition; render `/avatar.svg` with `svgr.macro`
- add storybook examples for general case and default case

## [](#how-to-test)How to test

1. `yarn start`
2. checkout `Avatar` section in localhost:6006